### PR TITLE
Resolved bento warnings

### DIFF
--- a/adjust
+++ b/adjust
@@ -223,7 +223,7 @@ class JavaService(Adjust):
 
         try:
             f = open(CFG_FILE)
-            d = yaml.load(f)
+            d = yaml.safe_load(f)
         except IOError as e:
             raise Exception(
                 "cannot read configuration from {}:{}".format(CFG_FILE, e.strerror))
@@ -476,7 +476,7 @@ class JavaService(Adjust):
                 if request_ts > end_ts:
                     break
 
-                r = requests.get(url, verify=False, timeout=READY_POLL_TIMEOUT)
+                r = requests.get(url, verify=False, timeout=READY_POLL_TIMEOUT) # nosec (Allow self-signed certs)
                 assert(r.status_code == 200), "http status " + str(r.status_code)
                 if expect is not None:
                     assert(str(expect) in r.text), "expected string not in response"


### PR DESCRIPTION
Bento Output:

```
bandit yaml-load https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html  
     > adjust:226                                                                     
     ╷                                                                                
  226│   d = yaml.load(f)                                                             
     ╵                                                                                
     = Use of unsafe yaml load. Allows instantiation of arbitrary objects.
       Consider yaml.safe_load().

bandit request-with-no-cert-validation https://bandit.readthedocs.io/en/latest/plugins/b501_request_with_no_cert_validation.html
     > adjust:479
     ╷
  479│   r = requests.get(url, verify=False, timeout=READY_POLL_TIMEOUT)
     ╵
     = Requests call with verify=False disabling SSL certificate checks,
       security issue.
```